### PR TITLE
Add support for callables in input and parameters values

### DIFF
--- a/airflow_valohai_plugin/operators/valohai_submit_execution_operator.py
+++ b/airflow_valohai_plugin/operators/valohai_submit_execution_operator.py
@@ -37,6 +37,19 @@ class ValohaiSubmitExecutionOperator(BaseOperator):
             self.valohai_conn_id
         )
 
+    def get_output_uri(self, dag_id, task_id, output_name, context):
+        execution_details = context['ti'].xcom_pull(
+            dag_id=dag_id,
+            task_ids=task_id,
+            include_prior_dates=True
+        )
+
+        for output in execution_details['outputs']:
+            if output['name'] == output_name:
+                return ['datum://{}'.format(output['id'])]
+
+        raise Exception('Failed to find uri for input with name {}'.format(output_name))
+
     def execute(self, context):
         hook = self.get_hook()
 

--- a/examples/dags/example_valohai_dag_pass_outputs.py
+++ b/examples/dags/example_valohai_dag_pass_outputs.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.valohai import ValohaiSubmitExecutionOperator
+
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': datetime(2018, 1, 1),
+    'email': ['airflow@example.com'],
+    'email_on_failure': False,
+    'email_on_retry': False
+}
+
+dag = DAG(
+    'example_valohai_dag_pass_outputs',
+    default_args=default_args,
+    schedule_interval=None,
+    catchup=False
+)
+
+
+preprocess = ValohaiSubmitExecutionOperator(
+    task_id='preprocess',
+    project_name='tensorflow-example',
+    step='Preprocess dataset (MNIST)',
+    dag=dag,
+    inputs={
+        'test-set-images': 'https://valohai-mnist.s3.amazonaws.com/t10k-images-idx3-ubyte.gz',
+        'test-set-labels': 'https://valohai-mnist.s3.amazonaws.com/t10k-labels-idx1-ubyte.gz',
+        'training-set-images': 'https://valohai-mnist.s3.amazonaws.com/train-images-idx3-ubyte.gz',
+        'training-set-labels': 'https://valohai-mnist.s3.amazonaws.com/train-labels-idx1-ubyte.gz'
+    },
+)
+
+
+class ValohaiTrainOperator(ValohaiSubmitExecutionOperator):
+
+    def execute(self, context):
+        dag_id = dag.dag_id
+        task_id = preprocess.task_id
+
+        self.inputs = {
+            'training-set-images': self.get_output_uri(
+                dag_id, task_id, 'mnist-train-images.gz', context),
+            'training-set-labels': self.get_output_uri(
+                dag_id, task_id, 'mnist-train-labels.gz', context),
+            'test-set-images': self.get_output_uri(
+                dag_id, task_id, 'mnist-test-images.gz', context),
+            'test-set-labels': self.get_output_uri(
+                dag_id, task_id, 'mnist-test-labels.gz', context),
+        }
+        super().execute(context)
+
+
+train = ValohaiTrainOperator(
+    task_id='train_model',
+    project_name='tensorflow-example',
+    step='Train model (MNIST)',
+    dag=dag,
+    inputs={},
+    parameters={
+        'dropout': 0.9,
+        'learning_rate': 0.001,
+        'max_steps': 300,
+        'batch_size': 200,
+    }
+)
+
+preprocess >> train


### PR DESCRIPTION
Add support for callables in input and parameter values. Those callables should take the context as an argument, and will be resolved at execution time. This is spcially useful to use as input the output of a previous execution, or dynamically set parameters from context.

It also adds the classmethod `get_output_uri` that can be useful and imported from client code.