### PR TITLE
Make inputs and parameters optional

### DIFF
--- a/airflow_valohai_plugin/operators/valohai_submit_execution_operator.py
+++ b/airflow_valohai_plugin/operators/valohai_submit_execution_operator.py
@@ -10,8 +10,8 @@ class ValohaiSubmitExecutionOperator(BaseOperator):
     Args:
         project_name (str): name of the project.
         step (str): name of the step.
-        inputs (dict): file inputs dictionary with name in keys and url in values.
-        parameters (dict): parameters with name in keys and value in values.
+        inputs (dict, optional): file inputs dictionary with name in keys and url in values.
+        parameters (dict, optional): parameters with name in keys and value in values.
         environment (str, optional): cloud environment to launch the execution.
             By default it takes the environment in the Valohai UI settings.
         commit (str, optional): commit hash.
@@ -27,12 +27,12 @@ class ValohaiSubmitExecutionOperator(BaseOperator):
         self,
         project_name,
         step,
-        inputs,
-        parameters,
+        inputs={},
+        parameters={},
         environment=None,
         commit=None,
         branch='master',
-        tags=None,
+        tags=[],
         valohai_conn_id='valohai_default',
         *args,
         **kwargs


### PR DESCRIPTION
Based on the [official API doc](https://app.valohai.com/api/docs/#executions-create) now only project, step and name are required to create an execution. In our case, we fill the commit with the latest commit on a branch (default master) if not provided.

Tested locally, and if not setting inputs and parameters, it takes the default ones in the `valohai.yaml` which helps having a single source of truth and simplifies code.