### PR TITLE
Decorate all operators with @apply_defaults

### DIFF
--- a/airflow_valohai_plugin/operators/valohai_download_execution_outputs_operator.py
+++ b/airflow_valohai_plugin/operators/valohai_download_execution_outputs_operator.py
@@ -3,6 +3,7 @@ import re
 from urllib.request import urlretrieve
 import logging
 
+from airflow.utils.decorators import apply_defaults
 from airflow.models import BaseOperator
 from airflow.configuration import AIRFLOW_HOME
 
@@ -24,6 +25,7 @@ class ValohaiDownloadExecutionOutputsOperator(BaseOperator):
     ui_color = '#fff'
     ui_fgcolor = '#000'
 
+    @apply_defaults
     def __init__(
         self,
         output_task,

--- a/airflow_valohai_plugin/operators/valohai_submit_execution_operator.py
+++ b/airflow_valohai_plugin/operators/valohai_submit_execution_operator.py
@@ -1,4 +1,5 @@
 from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
 
 from airflow_valohai_plugin.hooks.valohai_hook import ValohaiHook
 
@@ -33,6 +34,7 @@ class ValohaiSubmitExecutionOperator(BaseOperator):
     ui_color = '#002f6c'
     ui_fgcolor = '#fff'
 
+    @apply_defaults
     def __init__(
         self,
         project_name,


### PR DESCRIPTION
It seems to be a common practice to decorate all operators with [@appy_defaults](https://github.com/apache/airflow/blob/master/airflow/utils/decorators.py#L32)

Check for example, [BigQueryToBigQueryOperator](https://github.com/apache/airflow/blob/master/airflow/operators/bigquery_to_bigquery.py#L78)

The apply_defaults decorator apart from allowing to [pass default_args to a task](http://airflow.apache.org/tutorial.html#tasks). It does some argument validation like:
- Forcing to use keyword arguments when initializing operators
- Checking for required arguments

That can be useful to debug operators.

Locally I tested for example if I removed the required `step` argument. Error message is a bit different.

BEFORE
![image](https://user-images.githubusercontent.com/2302748/68761671-e045ba00-0614-11ea-8ece-089511abc72f.png)

AFTER
![image](https://user-images.githubusercontent.com/2302748/68761685-e471d780-0614-11ea-820a-9e4428c19bfe.png)

Good thing is that if someone does something like:
```
train_model = ValohaiSubmitExecutionOperator(
    'train_model',
    'tensorflow-example',
    step='Train model (MNIST)',
```
It will show the error:
```
Broken DAG: [/home/skillup/skillup/airflow-valohai-plugin/examples/dags/example_valohai_dag.py] Use keyword arguments when initializing operators
```

to force using the better:

```
train_model = ValohaiSubmitExecutionOperator(
    task_id='train_model',
    project_name='tensorflow-example',
    step='Train model (MNIST)',
...
```

