### PR TITLE
Add fail_if_missing to ValohaiDownloadExecutionOperator

### DIFF
--- a/airflow_valohai_plugin/operators/valohai_download_execution_outputs_operator.py
+++ b/airflow_valohai_plugin/operators/valohai_download_execution_outputs_operator.py
@@ -5,6 +5,7 @@ import logging
 
 from airflow.models import BaseOperator
 from airflow.configuration import AIRFLOW_HOME
+from airflow.exceptions import AirflowException
 
 
 class ValohaiDownloadExecutionOutputsOperator(BaseOperator):
@@ -20,6 +21,8 @@ class ValohaiDownloadExecutionOutputsOperator(BaseOperator):
             with a regex.
         output_path (str, optional): relative path to AIRFLOW_HOME where to
             store the outputs locally. By default stores ouputs in AIRFLOW_HOME.
+        fail_if_missing (boolean, optional): fail task if no output was found.
+            By default it fails.
     """
     ui_color = '#fff'
     ui_fgcolor = '#000'
@@ -30,6 +33,7 @@ class ValohaiDownloadExecutionOutputsOperator(BaseOperator):
         output_name=None,
         output_name_pattern=None,
         output_path='.',
+        fail_if_missing=True,
         *args,
         **kwargs
     ):
@@ -39,11 +43,18 @@ class ValohaiDownloadExecutionOutputsOperator(BaseOperator):
         self.output_name = output_name
         self.output_name_pattern = output_name_pattern
         self.output_path = output_path
+        self.fail_if_missing = fail_if_missing
 
     def get_output_path(self, name):
         return os.path.join(AIRFLOW_HOME, self.output_path, name)
 
+    def download_output(self, url, output_name):
+        output_path = self.get_output_path(output_name)
+        urlretrieve(url, output_path)
+        logging.info('Downloaded output {} to: {}'.format(output_name, output_path))
+
     def execute(self, context):
+        output_name = None
         execution_details = context['ti'].xcom_pull(
             dag_id=self.output_dag_id,
             task_ids=self.output_task_id,
@@ -52,20 +63,25 @@ class ValohaiDownloadExecutionOutputsOperator(BaseOperator):
         for output in execution_details['outputs']:
             if self.output_name:
                 if not self.output_name == output['name']:
-                    logging.info('Ignore ouput name {}'.format(
-                        output['name']))
+                    msg = 'Ignore ouput name {}'.format(output['name'])
+                    logging.info(msg)
                     continue
                 output_name = self.output_name
             elif self.output_name_pattern:
                 name_match = re.match(self.output_name_pattern, output['name'])
                 if not name_match:
-                    logging.info('Ignore ouput name {} because failed to match pattern {}'.format(
-                        output['name'], self.output_name_pattern))
+                    msg = 'Ignore ouput name {} because failed to match pattern {}'.format(
+                        output['name'], self.output_name_pattern)
+                    logging.info(msg)
                     continue
                 output_name = name_match.group(0)
             else:
                 output_name = output['name']
 
-            output_path = self.get_output_path(output_name)
-            urlretrieve(output['url'], output_path)
-            logging.info('Downloaded output {} to: {}'.format(output_name, output_path))
+            self.download_output(output['url'], output_name)
+
+        if output_name is None and self.fail_if_missing:
+            msg = 'Failed to find any output for '
+            msg += 'task_id: {}, output_name: {}, output_name_pattern: {}'.format(
+                self.output_task_id, self.output_name, self.output_name_pattern)
+            raise AirflowException(msg)


### PR DESCRIPTION
With this code, If no output is downloaded it fails by default. It will be clearer to avoid triggering downstream tasks in case the filename did not match.

I tested locally. For example if we now set `output_name='model.pbt'` instead of `output_name='model.pb'` we get:

```
[2019-11-13 16:43:08,861] {base_task_runner.py:101} INFO - Job 135: Subtask download_model airflow.exceptions.AirflowException: Failed to find any output for task_id: train_model, output_name: model.pbt, output_name_pattern: None
[2019-11-13 16:43:13,166] {logging_mixin.py:95} INFO - [2019-11-13 16:43:13,165] {jobs.py:2562} INFO - Task exited with return code 1
```