### PR TITLE
Add GitHub Actions basic CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,5 @@ jobs:
         flake8 airflow_valohai_plugin tests examples setup.py
     - name: Run unit tests
       run: |
+        pip install .
         AIRFLOW_HOME=$PWD/tests ./run_unit_tests.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements-dev.txt
+    - name: Lint with flake8
+      run: |
+        flake8 airflow_valohai_plugin tests examples setup.py
+    - name: Run unit tests
+      run: |
+        AIRFLOW_HOME=$PWD/tests ./run_unit_tests.sh


### PR DESCRIPTION
Basic CI using GitHub Actions instead of CircleCI from this PR: https://github.com/skillupco/airflow-valohai-plugin/pull/12

This looks like it is not build passing due to the issue referenced in this PR: https://github.com/skillupco/airflow-valohai-plugin/pull/13#pullrequestreview-315729924

Merging PR 13 first and doing rebase should make the CI pass. Or do you want to proceed any other way?